### PR TITLE
Update tldextract cache for pywb during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ ADD package.json /app/
 # to allow forcing rebuilds from this stage
 ARG REBUILD
 
+# Prefetch tldextract so pywb is able to boot in environments with limited internet access
+RUN tldextract --update 
+
 # Download and format ad host blocklist as JSON
 RUN mkdir -p /tmp/ads && cd /tmp/ads && \
     curl -vs -o ad-hosts.txt https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts && \


### PR DESCRIPTION
Pywb is unable to function when it's unable to refresh its tld cache. Unfortunately that's not so straightforward in the environment where I have to deploy it. With this change I'm able to run crawls without any internet access except for a socks proxy.